### PR TITLE
Added optional uvloop support.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 yarl<1.2
 numpy==1.14.0
+uvloop

--- a/run.py
+++ b/run.py
@@ -15,6 +15,12 @@ from src.config.config import LoadConfig
 # If uvloop is installed, change to that eventloop policy as it 
 # is more efficient
 try:
+    # Temp fix for https://github.com/MagicStack/uvloop/pull/138
+    # until it hopefully gets fixed by next week?
+    import sys
+    if sys.version_info()[1] > 6:
+        raise RuntimeError('Disabling uvloop for Python3.7 and newer.')
+    
     import uvloop
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
     del uvloop

--- a/run.py
+++ b/run.py
@@ -2,6 +2,7 @@
 # -*- coding: utf8 -*-
 
 # Import packages
+import asyncio
 import discord
 from discord.ext import commands
 import json
@@ -10,6 +11,18 @@ import random
 
 # Import custom files
 from src.config.config import LoadConfig
+
+# If uvloop is installed, change to that eventloop policy as it 
+# is more efficient
+try:
+    import uvloop
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    del uvloop
+except BaseException as ex:
+    print(f'Could not load uvloop. {type(ex).__name__}: {ex};',
+          'reverting to default impl.')
+else:
+    print(f'Using uvloop for asyncio event loop policy.')
 
 
 # Bot Class


### PR DESCRIPTION
uvloop uses libs used by node.js and has been shown to be a much more efficient event loop policy than the default Python asyncio implementation. If uvloop is installed, this is quietly changed before the bot is initialised. If uvloop cannot be set, either from not being installed, or from being used on an unsupported system such as Windoze, then nothing is changed.

The only change should be a slight increase in throughput if it is detected.

Please test first.